### PR TITLE
Fix: Correct URDF mesh path resolution and guide you

### DIFF
--- a/main.js
+++ b/main.js
@@ -432,7 +432,8 @@ function onFileSelected(event) {
                     const ext = resolvedPath.split('.').pop().toLowerCase();
                     let loader;
 
-                    const basePathForSubloader = urdfLoader.workingPath || '';
+                    const basePathForSubloader = urdfLoader.path || '';
+                    console.log('[URDF Resource] Using base path for sub-loader (from urdfLoader.path): "' + basePathForSubloader + '"');
                     console.log(`[URDF Resource] Trying to load: "${resolvedPath}", Extension: ${ext}, Base for sub-loader: "${basePathForSubloader}"`);
 
                     const placeholderMaterial = new THREE.MeshPhongMaterial({color: Math.random() * 0xffffff, wireframe: true, name: `Placeholder for ${resolvedPath}`});
@@ -496,12 +497,24 @@ function onFileSelected(event) {
                 };
 
                 console.log("[URDFLoad] Attempting to parse URDF data for:", file.name);
-                loadedModel = urdfLoader.parse(e.target.result, file.name);
+                let urdfParsePath = file.name;
+                if (file.name.toLowerCase() === 'go2_description.urdf') {
+                    urdfParsePath = 'URDF/' + file.name;
+                    console.log('[URDFLoad] Detected go2_description.urdf, setting parse path to: ' + urdfParsePath);
+                }
+                loadedModel = urdfLoader.parse(e.target.result, urdfParsePath);
 
                 if (loadedModel) {
                     console.log("[URDFLoad] URDF model parsed successfully:", loadedModel.name || filename);
                     showStatus(`Parsed "${filename}". Loading meshes...`);
                     scene.add(loadedModel);
+
+                    if (file.name.toLowerCase() === 'go2_description.urdf') {
+                        const meshLocationMessage = "For 'go2_description.urdf', ensure DAE mesh files (base.dae, hip.dae, etc.) are in 'URDF/dae/' relative to index.html.";
+                        showStatus(meshLocationMessage, false); // 'false' for not an error
+                        console.log("[URDFLoad] User guidance: " + meshLocationMessage);
+                    }
+
                     fitCameraToObject(loadedModel, 2.5);
                     armElements.forEach(el => { if (el) el.visible = false; });
                     showStatus(`URDF "${filename}" structure loaded. Meshes loading... Check console.`, false, false);


### PR DESCRIPTION
This commit addresses an issue where URDF meshes, particularly for `go2_description.urdf`, were not being found, likely resulting in a white screen.

Changes:
- Modified `main.js` in `onFileSelected`:
    - The `urdfLoader.parse()` method is now called with a more accurate path for `go2_description.urdf` (`URDF/go2_description.urdf` instead of just the filename). This allows the loader to correctly establish its internal base path (`URDF/`).
- Modified `main.js` in `urdfLoader.loadMeshCb`:
    - The base path for sub-loaders (Collada, STL, OBJ) is now derived from `urdfLoader.path` (the URDF's own directory path) instead of `urdfLoader.workingPath` (which was the HTML file's directory).
    - This ensures that stripped mesh paths (e.g., `dae/base.dae` from `package://<name>/dae/base.dae`) are correctly resolved relative to the URDF file's location (e.g., `URDF/dae/base.dae`).
- Added user guidance:
    - When `go2_description.urdf` is loaded, a status message and console log now inform you to place the required DAE mesh files into the `URDF/dae/` directory.

These changes should allow the `go2_description` robot model to load its meshes correctly if they are placed in the specified directory. If meshes are missing, the existing placeholder system and camera fallbacks should provide a more informative display than a blank white screen.