### PR TITLE
Fix: Update URDFLoader.js CDN URL and add library checks

### DIFF
--- a/index.html
+++ b/index.html
@@ -13,7 +13,7 @@
     <script src="https://cdn.jsdelivr.net/gh/mrdoob/three.js@r128/examples/js/loaders/STLLoader.js"></script>
     <script src="https://cdn.jsdelivr.net/gh/mrdoob/three.js@r128/examples/js/loaders/OBJLoader.js"></script>
     <script src="https://cdn.jsdelivr.net/gh/mrdoob/three.js@r128/examples/js/loaders/ColladaLoader.js"></script>
-    <script src="https://cdn.jsdelivr.net/gh/mrdoob/three.js@r128/examples/js/loaders/URDFLoader.js"></script>
+    <script src="https://unpkg.com/three@0.128.0/examples/js/loaders/URDFLoader.js"></script>
     <script src="main.js" defer></script>
 </body>
 </html>

--- a/main.js
+++ b/main.js
@@ -121,8 +121,25 @@ function initAmmo(AmmoLib) {
  */
 function init() {
     console.log("init: Script execution started.");
-    showStatus("Main script running...", false, true); // Existing robust showStatus will be applied later
-    initThreeJS(); // Existing initThreeJS will be updated later
+    // Add pre-emptive checks here:
+    if (typeof THREE === 'undefined') {
+        console.error("THREE object is undefined! three.min.js might have failed to load. Application cannot start.");
+        alert("Critical Error: THREE.js core library not loaded. Application cannot start. Check browser console (F12) for Network errors.");
+        return; // Halt execution
+    }
+    if (typeof THREE.URDFLoader === 'undefined') {
+        const criticalMessage = "THREE.URDFLoader is undefined! URDFLoader.js likely failed to load or is incorrect. Check Network tab in browser console (F12).";
+        console.error(criticalMessage);
+        // Attempt to use showStatus, which will fallback to alert if statusElement isn't ready
+        // (initThreeJS, which initializes statusElement, is called after this check)
+        // So, an alert is more reliable here.
+        alert(criticalMessage);
+        // Do not return yet, allow initThreeJS to run to set up basic scene and status element for other messages.
+        // The URDF loading will fail later, but at least some UI might appear.
+    }
+
+    showStatus("Main script running...", false, true); // This message might be overridden by the alert above if URDFLoader is missing.
+    initThreeJS();
     console.log("init: Attempting to load Ammo.js...");
     Ammo().then(function (AmmoLib) { // Ammo() is from ammo.wasm.js
         console.log("init: Ammo.js library loaded successfully.");
@@ -131,7 +148,7 @@ function init() {
     }).catch(e => {
         console.error("init: Error loading Ammo.js:", e);
         showStatus("Fatal Error: Could not load Physics Engine (Ammo.js). Check console.", true);
-        animate();
+        animate(); // Still call animate to render scene, even if physics is off
     });
 }
 


### PR DESCRIPTION
This commit attempts to resolve the "THREE.URDFLoader is not a constructor" error by:
1. Changing the CDN URL for `URDFLoader.js` (for Three.js r128) in `index.html` from jsDelivr to unpkg.com, as the jsDelivr URL was returning a "File not found" error.
2. Adding pre-emptive checks in `main.js`'s `init()` function to verify that `THREE` and `THREE.URDFLoader` are defined. These checks will trigger alert messages if the core library or the loader script fails to load, providing earlier and clearer error feedback.

This aims to ensure `URDFLoader.js` is correctly loaded or to provide immediate notice if it fails.