### PR TITLE
Feat: Update index.html to use placeholder main.bundle.js

### DIFF
--- a/index.html
+++ b/index.html
@@ -9,6 +9,6 @@
     <input type="file" id="fileInput" style="position: absolute; top: 10px; left: 10px;">
     <script async src="https://cdn.jsdelivr.net/gh/kripken/ammo.js@HEAD/builds/ammo.wasm.js"></script>
     <script src="https://unpkg.com/three@0.158.0/build/three.module.js"></script>
-    <script type="module" src="main.js"></script>
+    <script src="main.bundle.js"></script>
 </body>
 </html>

--- a/main.bundle.js
+++ b/main.bundle.js
@@ -1,0 +1,56 @@
+// main.bundle.js (placeholder)
+// This file will be replaced by the actual bundled application code.
+console.log('main.bundle.js placeholder script has loaded and executed.');
+
+// Define a minimal global init and showStatus for index.html to call without erroring immediately
+// In the real bundle, these would be the full versions from main.js,
+// properly scoped or exposed globally by the bundler if main.js calls init() itself.
+var statusElement; // Keep it simple for the placeholder
+
+window.showStatus = function(message, isError, isSuccess) {
+    var displayMessage = 'Bundled Status: ' + message;
+    console.log(displayMessage);
+    if (statusElement) {
+        statusElement.textContent = displayMessage;
+        statusElement.style.display = 'block';
+        // Reset classes simply
+        statusElement.className = 'status-message';
+        if (isError) statusElement.classList.add('error');
+        if (isSuccess) statusElement.classList.add('success');
+        // Auto-hide for non-errors
+        if (!isError) {
+            setTimeout(function() {
+                if (statusElement) statusElement.style.display = 'none';
+            }, isSuccess ? 2000 : 4000);
+        }
+    } else {
+        // Avoid alert spam from placeholder, just log if statusElement isn't found yet
+        console.warn('statusElement not ready for message: ' + message);
+    }
+};
+
+window.init = function() {
+    // Try to get statusElement like in the real initThreeJS
+    statusElement = document.getElementById('statusMessage');
+    if (statusElement) {
+        console.log('main.bundle.js placeholder: statusMessage element found.');
+        window.showStatus('main.bundle.js placeholder initialized.', false, true);
+    } else {
+        console.warn('main.bundle.js placeholder: statusMessage element NOT found.');
+        alert('main.bundle.js placeholder initialized (statusElement not found).');
+    }
+    // Simulate file input listener setup for basic UI feedback
+    const fileInput = document.getElementById('fileInput');
+    if (fileInput) {
+        fileInput.addEventListener('change', function(event) {
+            if (event.target.files.length > 0) {
+                window.showStatus('Placeholder: File selected: ' + event.target.files[0].name, false, true);
+            }
+        });
+    }
+};
+
+// Call init, simulating what the original main.js did at its end.
+// The bundler would typically wrap the original main.js, and if it ended with init(),
+// that call would execute when the bundle loads.
+window.init();


### PR DESCRIPTION
This commit modifies `index.html` to load `main.bundle.js` as a standard script. `main.bundle.js` currently contains placeholder JavaScript code.

This change is part of an effort to enable the application to run via the `file:///` protocol by eventually using a fully bundled JavaScript file, thus avoiding ES6 module loading restrictions.

This commit allows testing whether the `file:///` module-related errors are resolved by switching to a non-module script tag. The placeholder bundle should execute and display basic messages. The actual application logic and 3D rendering will not function with this placeholder.