### PR TITLE
Fix: Remove direct loading of three.module.js from index.html

### DIFF
--- a/index.html
+++ b/index.html
@@ -8,7 +8,6 @@
     <div id="statusMessage" class="status-message"></div>
     <input type="file" id="fileInput" style="position: absolute; top: 10px; left: 10px;">
     <script async src="https://cdn.jsdelivr.net/gh/kripken/ammo.js@HEAD/builds/ammo.wasm.js"></script>
-    <script src="https://unpkg.com/three@0.158.0/build/three.module.js"></script>
     <script src="main.bundle.js"></script>
 </body>
 </html>


### PR DESCRIPTION
This commit removes the explicit <script> tag for three.module.js from index.html. This was causing a "SyntaxError: Unexpected token 'export'" because three.module.js was being loaded as a regular script instead of being part of the module graph, and it was conflicting with the move to a bundled main.bundle.js.

With this change, index.html now only loads ammo.wasm.js and main.bundle.js. The intention is that main.bundle.js will eventually contain all necessary Three.js code. This change allows for cleaner testing of the (currently placeholder) main.bundle.js execution via the file:/// protocol.