### PR TITLE
Fix: Correct WebGLRenderer stub and Ammo.js initialization

### DIFF
--- a/three_with_loaders.bundle.js
+++ b/three_with_loaders.bundle.js
@@ -27,7 +27,7 @@ window.THREE = (function() {
     THREE.Color.prototype.set = function(r,g,b) { this.r=r; this.g=g; this.b=b; };
     THREE.Scene = function() { console.log('THREE.Scene stub created'); this.background=null; this.children=[]; this.add = function(obj){this.children.push(obj);}; this.remove = function(obj){this.children = this.children.filter(o => o !== obj);};};
     THREE.PerspectiveCamera = function() { console.log('THREE.PerspectiveCamera stub created'); this.position = new THREE.Vector3(); this.lookAt=function(){}; this.updateProjectionMatrix=function(){}; this.getWorldDirection=function(v){ return v.set(0,0,-1);}; };
-    THREE.WebGLRenderer = function() { console.log('THREE.WebGLRenderer stub created'); this.domElement = { addEventListener: function(){}, style: {} }; this.setSize = function(){}; this.render = function(){}; };
+    THREE.WebGLRenderer = function() { console.log('THREE.WebGLRenderer stub created'); this.domElement = document.createElement('canvas'); this.domElement.width = 300; this.domElement.height = 150; console.log('THREE.WebGLRenderer stub: created canvas domElement'); this.setSize = function(w,h){ console.log('THREE.WebGLRenderer stub: setSize called with', w, h); this.domElement.width = w; this.domElement.height = h; }; this.render = function(s,c){ console.log('THREE.WebGLRenderer stub: render called'); }; };
     THREE.AmbientLight = function() { console.log('THREE.AmbientLight stub created'); };
     THREE.DirectionalLight = function() { console.log('THREE.DirectionalLight stub created'); this.position = new THREE.Vector3(); };
     THREE.BoxGeometry = function() { console.log('THREE.BoxGeometry stub created'); };


### PR DESCRIPTION
This commit addresses two critical issues found during testing with the stubbed multi-file JavaScript setup:

1.  **Corrected `THREE.WebGLRenderer` stub:**
    - The `THREE.WebGLRenderer` stub in `three_with_loaders.bundle.js` now initializes its `domElement` property with `document.createElement('canvas')`. This resolves the `TypeError: Failed to execute 'appendChild' on 'Node'` that occurred because the previous stub used a plain object for `domElement`.

2.  **Robust Ammo.js Initialization:**
    - The `init()` function in `main_app.js` now includes a polling mechanism (using `setTimeout`) that waits for the global `Ammo` function to be defined by the asynchronously loaded `ammo.wasm.js` before attempting to call `Ammo().then(...)`. This fixes the `Uncaught ReferenceError: Ammo is not defined`.

These changes should allow your application (with stubs) to initialize without these specific errors when run via `file:///`, enabling further testing of the application's logic flow.