### PR TITLE
Feat: Update with more functional Three.js stubs

### DIFF
--- a/three_with_loaders.bundle.js
+++ b/three_with_loaders.bundle.js
@@ -1,124 +1,132 @@
-// three_with_loaders.bundle.js (Placeholder with Stubs)
+// three_with_loaders.bundle.js (More Functional, but still partial, Bundle)
+// This simulates replacing stubs with a working, albeit incomplete, library.
+// The real bundle would contain the full minified Three.js r158 and loaders.
 
-// --- Minimal THREE.js Stub ---
-window.THREE = (function() {
-    console.log('THREE.js stub initialized');
-    const THREE = {}; // Local THREE namespace for stubbing
+(function() { // IIFE to encapsulate and manage scope
 
-    THREE.REVISION = '158-stub';
+    console.log('Executing three_with_loaders.bundle.js (Functional Partial Bundle)...');
 
-    // Basic Vector classes (simplified)
-    THREE.Vector2 = function(x, y) { this.x = x || 0; this.y = y || 0; };
-    THREE.Vector3 = function(x, y, z) { this.x = x || 0; this.y = y || 0; this.z = z || 0; };
-    THREE.Vector3.prototype = {
-        set: function(x,y,z) { this.x=x; this.y=y; this.z=z; return this; },
-        copy: function(v) { this.x=v.x; this.y=v.y; this.z=v.z; return this; },
+    // --- Minimal THREE.js Core Simulation ---
+    const THREE_CORE = {};
+    THREE_CORE.REVISION = '158-partial-bundle';
+
+    THREE_CORE.Vector3 = function(x, y, z) {
+        this.x = x || 0; this.y = y || 0; this.z = z || 0;
+    };
+    THREE_CORE.Vector3.prototype = {
+        set: function(x, y, z) { this.x = x; this.y = y; this.z = z; return this; },
+        copy: function(v) { this.x = v.x; this.y = v.y; this.z = v.z; return this; },
         addScaledVector: function(v, s) { this.x += v.x * s; this.y += v.y * s; this.z += v.z * s; return this; },
         normalize: function() { const l = Math.sqrt(this.x*this.x+this.y*this.y+this.z*this.z) || 1; this.x/=l; this.y/=l; this.z/=l; return this;},
-        getCenter: function(v) { return v.copy(this); }, // Mock for Box3
-        getSize: function(v) { return v.set(0,0,0); } // Mock for Box3
+        clone: function() { return new THREE_CORE.Vector3(this.x, this.y, this.z); }
     };
-    THREE.Quaternion = function(x,y,z,w) { this.x=x||0; this.y=y||0; this.z=z||0; this.w=(w===undefined)?1:w; };
-    THREE.Quaternion.prototype = {
+    THREE_CORE.Quaternion = function(x,y,z,w) { this.x=x||0; this.y=y||0; this.z=z||0; this.w=(w===undefined)?1:w; };
+    THREE_CORE.Quaternion.prototype = {
         set: function(x,y,z,w) {this.x=x; this.y=y; this.z=z; this.w=w; return this;},
-        copy: function(q) {this.x=q.x; this.y=q.y; this.z=q.z; this.w=q.w; return this;}
+        copy: function(q) {this.x=q.x; this.y=q.y; this.z=q.z; this.w=q.w; return this;},
+        clone: function() { return new THREE_CORE.Quaternion(this.x, this.y, this.z, this.w); }
     };
-    THREE.Color = function(r,g,b) { this.r=r; this.g=g; this.b=b; console.log('THREE.Color stub created');};
-    THREE.Color.prototype.set = function(r,g,b) { this.r=r; this.g=g; this.b=b; };
-    THREE.Scene = function() { console.log('THREE.Scene stub created'); this.background=null; this.children=[]; this.add = function(obj){this.children.push(obj);}; this.remove = function(obj){this.children = this.children.filter(o => o !== obj);};};
-    THREE.PerspectiveCamera = function() { console.log('THREE.PerspectiveCamera stub created'); this.position = new THREE.Vector3(); this.lookAt=function(){}; this.updateProjectionMatrix=function(){}; this.getWorldDirection=function(v){ return v.set(0,0,-1);}; };
-    THREE.WebGLRenderer = function() { console.log('THREE.WebGLRenderer stub created'); this.domElement = document.createElement('canvas'); this.domElement.width = 300; this.domElement.height = 150; console.log('THREE.WebGLRenderer stub: created canvas domElement'); this.setSize = function(w,h){ console.log('THREE.WebGLRenderer stub: setSize called with', w, h); this.domElement.width = w; this.domElement.height = h; }; this.render = function(s,c){ console.log('THREE.WebGLRenderer stub: render called'); }; };
-    THREE.AmbientLight = function() { console.log('THREE.AmbientLight stub created'); };
-    THREE.DirectionalLight = function() { console.log('THREE.DirectionalLight stub created'); this.position = new THREE.Vector3(); };
-    THREE.BoxGeometry = function() { console.log('THREE.BoxGeometry stub created'); };
-    THREE.SphereGeometry = function() { console.log('THREE.SphereGeometry stub created'); };
-    THREE.MeshPhongMaterial = function(params) { console.log('THREE.MeshPhongMaterial stub created with params:', params); this.name = params && params.name ? params.name : ''; };
-    THREE.MeshBasicMaterial = function(params) { console.log('THREE.MeshBasicMaterial stub created with params:', params);};
-    THREE.Mesh = function(geo, mat) { console.log('THREE.Mesh stub created'); this.position = new THREE.Vector3(); this.quaternion = new THREE.Quaternion(); this.name=''; this.visible=true; this.children=[]; this.add=function(obj){this.children.push(obj);}; this.geometry=geo; this.material=mat;};
-    THREE.Plane = function() { console.log('THREE.Plane stub created'); this.normal = new THREE.Vector3(); this.setFromNormalAndCoplanarPoint = function(){};};
-    THREE.Raycaster = function() { console.log('THREE.Raycaster stub created'); this.setFromCamera=function(){}; this.intersectObject=function(){return []}; this.ray={intersectPlane:function(){return null;}};};
-    THREE.Object3D = function() { this.position = new THREE.Vector3(); this.quaternion = new THREE.Quaternion(); this.children = []; this.add = function(child) { this.children.push(child); }; this.remove = function(child) { const index = this.children.indexOf(child); if (index !== -1) this.children.splice(index, 1);}; this.traverse = function(cb){cb(this); this.children.forEach(c=>c.traverse(cb));}; this.name = ''; this.visible = true;};
-    THREE.Group = function() { THREE.Object3D.call(this); console.log('THREE.Group stub created'); };
-    THREE.Group.prototype = Object.create(THREE.Object3D.prototype);
-    THREE.LoadingManager = function(onLoad, onProgress, onError) {
-        console.log('THREE.LoadingManager stub created');
-        this.onLoad = onLoad; this.onProgress = onProgress; this.onError = onError;
-        this.itemStart = function(){}; this.itemEnd = function(){}; this.itemError = function(){};
-        // Simulate immediate load for simplicity in stub
-        if (this.onLoad) setTimeout(this.onLoad, 0);
+    THREE_CORE.Color = function(r, g, b) {
+        if (g === undefined && b === undefined) { this.setHex(r); } else { this.setRGB(r,g,b); }
     };
-    THREE.Box3 = function() {
-        this.min = new THREE.Vector3(-1,-1,-1); this.max = new THREE.Vector3(1,1,1);
-        this.setFromObject = function(obj) { console.log('THREE.Box3.setFromObject stub called'); return this; };
-        this.getCenter = function(target) { return target.set((this.min.x+this.max.x)/2, (this.min.y+this.max.y)/2, (this.min.z+this.max.z)/2); };
-        this.getSize = function(target) { return target.set(this.max.x-this.min.x, this.max.y-this.min.y, this.max.z-this.min.z); };
-        this.getBoundingSphere = function(target) { console.log('THREE.Box3.getBoundingSphere stub called'); target.radius = 1; return target; };
+    THREE_CORE.Color.prototype = {
+        setRGB: function(r,g,b) { this.r=r; this.g=g; this.b=b; return this;},
+        setHex: function(hex) { hex = Math.floor(hex); this.r = (hex >> 16 & 255) / 255; this.g = (hex >> 8 & 255) / 255; this.b = (hex & 255) / 255; return this;},
+        clone: function() { return new THREE_CORE.Color(this.r, this.g, this.b); }
     };
-    THREE.Sphere = function(center, radius) { this.center = center || new THREE.Vector3(); this.radius = radius || 0; };
-    THREE.Clock = function() { this.getDelta = function() { return 1/60; } };
+    THREE_CORE.Object3D = function() {
+        this.position = new THREE_CORE.Vector3();
+        this.quaternion = new THREE_CORE.Quaternion();
+        this.children = [];
+        this.up = new THREE_CORE.Vector3(0,1,0);
+        this.name = '';
+        this.visible = true;
+        this.add = function(child) { if (child === this) { console.error('THREE.Object3D.add: An object can\'t be added as a child of itself.'); return this;} this.children.push(child); child.parent = this; return this; };
+        this.remove = function(child) { const index = this.children.indexOf(child); if (index !== -1) { child.parent = null; this.children.splice(index, 1);}};
+        this.lookAt = function(vector) { /* simplified */ console.log('Object3D.lookAt called');};
+        this.getWorldDirection = function(target) { return target.set(0,0,-1).applyQuaternion(this.quaternion);}; // Simplified
+        this.traverse = function(callback) { callback(this); for(let i=0; i<this.children.length; i++) { this.children[i].traverse(callback); } };
+    };
+    THREE_CORE.Group = function() { THREE_CORE.Object3D.call(this); this.type = 'Group'; };
+    THREE_CORE.Group.prototype = Object.assign(Object.create(THREE_CORE.Object3D.prototype), { constructor: THREE_CORE.Group });
+    THREE_CORE.Scene = function() { THREE_CORE.Object3D.call(this); this.type = 'Scene'; this.background = null; };
+    THREE_CORE.Scene.prototype = Object.assign(Object.create(THREE_CORE.Object3D.prototype), { constructor: THREE_CORE.Scene });
+    THREE_CORE.PerspectiveCamera = function(fov, aspect, near, far) { THREE_CORE.Object3D.call(this); this.type='PerspectiveCamera'; this.fov=fov; this.aspect=aspect; this.near=near; this.far=far; this.updateProjectionMatrix = function(){ console.log('PerspectiveCamera.updateProjectionMatrix called');};};
+    THREE_CORE.PerspectiveCamera.prototype = Object.assign(Object.create(THREE_CORE.Object3D.prototype), { constructor: THREE_CORE.PerspectiveCamera });
+    THREE_CORE.WebGLRenderer = function(params) {
+        console.log('THREE.WebGLRenderer functional stub created');
+        this.domElement = document.createElement('canvas');
+        this.domElement.width = (params && params.canvas) ? params.canvas.width : 300;
+        this.domElement.height = (params && params.canvas) ? params.canvas.height : 150;
+        this.setSize = function(width, height) { this.domElement.width = width; this.domElement.height = height; console.log('Renderer.setSize:', width, height); };
+        this.render = function(scene, camera) { /* console.log('Renderer.render called'); */ }; // Too noisy
+        this.setAnimationLoop = function(callback) { this.animationLoop = callback; console.log('Renderer.setAnimationLoop set.'); function loop() { callback(); requestAnimationFrame(loop); } requestAnimationFrame(loop); };
+    };
+    THREE_CORE.AmbientLight = function(color, intensity) { THREE_CORE.Object3D.call(this); this.type = 'AmbientLight'; this.color = new THREE_CORE.Color(color); this.intensity = intensity;};
+    THREE_CORE.AmbientLight.prototype = Object.assign(Object.create(THREE_CORE.Object3D.prototype), { constructor: THREE_CORE.AmbientLight });
+    THREE_CORE.DirectionalLight = function(color, intensity) { THREE_CORE.Object3D.call(this); this.type = 'DirectionalLight'; this.color = new THREE_CORE.Color(color); this.intensity = intensity;};
+    THREE_CORE.DirectionalLight.prototype = Object.assign(Object.create(THREE_CORE.Object3D.prototype), { constructor: THREE_CORE.DirectionalLight });
+    THREE_CORE.BoxGeometry = function(w,h,d) {this.type='BoxGeometry'; console.log('BoxGeometry created:',w,h,d);};
+    THREE_CORE.SphereGeometry = function(r) {this.type='SphereGeometry'; console.log('SphereGeometry created:',r);};
+    THREE_CORE.MeshPhongMaterial = function(params) { this.type='MeshPhongMaterial'; this.color = params.color || new THREE_CORE.Color(0xffffff); this.wireframe = params.wireframe || false; this.name = params.name || ''; console.log('MeshPhongMaterial created:', params);};
+    THREE_CORE.Mesh = function(geometry, material) { THREE_CORE.Object3D.call(this); this.type = 'Mesh'; this.geometry = geometry; this.material = material; console.log('Mesh created');};
+    THREE_CORE.Mesh.prototype = Object.assign(Object.create(THREE_CORE.Object3D.prototype), { constructor: THREE_CORE.Mesh });
+    THREE_CORE.Plane = function() {this.type='Plane'; this.normal = new THREE_CORE.Vector3(0,1,0); this.constant = 0; this.setFromNormalAndCoplanarPoint=function(n,p){this.normal.copy(n); this.constant = -p.dot(this.normal); return this;};}; // Simplified Plane
+    THREE_CORE.Raycaster = function(o,d,n,f){this.ray={origin:new THREE_CORE.Vector3(),direction:new THREE_CORE.Vector3()}; this.near=n||0; this.far=f||Infinity; this.setFromCamera=function(coords,cam){console.log('Raycaster.setFromCamera');}; this.intersectObject=function(obj,recursive){console.log('Raycaster.intersectObject'); return[];};};
+    THREE_CORE.LoadingManager = function(onLoad,onProgress,onError){this.onLoad=onLoad;this.onProgress=onProgress;this.onError=onError; this.itemStart=function(url){console.log('LoadingManager: itemStart',url)};this.itemEnd=function(url){console.log('LoadingManager: itemEnd',url); if(this.onLoad && !this.loading)this.onLoad();};this.itemError=function(url){console.log('LoadingManager: itemError',url); if(this.onError)this.onError(url);}; console.log('LoadingManager created');};
+    THREE_CORE.Clock = function(autoStart) { this.autoStart = (autoStart !== undefined) ? autoStart : true; this.startTime = 0; this.oldTime = 0; this.elapsedTime = 0; this.running = false; if (this.autoStart) this.start(); };
+    THREE_CORE.Clock.prototype = { start: function() {this.startTime=performance.now(); this.oldTime=this.startTime; this.elapsedTime=0; this.running=true;}, stop:function(){this.getElapsedTime();this.running=false;}, getElapsedTime:function(){this.getDelta();return this.elapsedTime;}, getDelta:function(){let diff=0;if(this.running){const newTime=performance.now();diff=(newTime-this.oldTime)/1000;this.oldTime=newTime;this.elapsedTime+=diff;}return diff;}};
+    THREE_CORE.Box3 = function(min, max) { this.min = (min !== undefined) ? min : new THREE_CORE.Vector3(+Infinity,+Infinity,+Infinity); this.max = (max !== undefined) ? max : new THREE_CORE.Vector3(-Infinity,-Infinity,-Infinity);};
+    THREE_CORE.Box3.prototype = { setFromObject: function(obj){console.log('Box3.setFromObject (stub)'); return this;}, getCenter: function(target){return target.copy(this.min).add(this.max).multiplyScalar(0.5);}, getSize:function(target){return target.copy(this.max).sub(this.min);}, getBoundingSphere: function(target){console.log('Box3.getBoundingSphere (stub)'); target.radius=this.getSize(new THREE_CORE.Vector3()).length()/2; target.center.copy(this.getCenter(new THREE_CORE.Vector3())); return target;}};
+    THREE_CORE.Sphere = function(center, radius){ this.center = (center !== undefined) ? center : new THREE_CORE.Vector3(); this.radius = (radius !== undefined) ? radius : -1;};
 
-    return THREE;
-})();
+    window.THREE = THREE_CORE;
 
-// --- Loader Stubs ---
-window.URDFLoader = function(manager) {
-    console.log('URDFLoader stub created');
-    this.path = ''; // For compatibility with how main_app.js might use it
-    this.load = function(url, onLoad, onProgress, onError) {
-        console.log('URDFLoader.load stub called for:', url);
-        if (onLoad) {
-            // Return a minimal robot object (empty group)
+    // --- Loader Implementations (Simplified stubs for brevity in this example) ---
+    // In a real scenario, the full minified code for these loaders would be here.
+    window.URDFLoader = function(manager) {
+        this.manager = manager || new window.THREE.LoadingManager();
+        this.path = '';
+        this.workingPath = '';
+        this.loadMeshCb = function() {}; // Default
+        this.parse = function(content, path) {
+            console.log('URDFLoader (functional stub): Parsing content. Path:', path);
+            this.path = path || '';
             const robot = new window.THREE.Group();
-            robot.name = url;
-            console.log('URDFLoader.load stub: calling onLoad with empty robot structure.');
-            onLoad(robot);
-        } else {
-            console.warn('URDFLoader.load stub: no onLoad callback provided.');
-        }
+            robot.name = 'robot_from_urdf_stub';
+            // Simulate trying to load one mesh
+            if (this.loadMeshCb) {
+                this.manager.itemStart('stub_mesh.stl');
+                this.loadMeshCb('package://pkg/stub_mesh.stl', this.manager, function(mesh_stub){
+                    robot.add(mesh_stub || new window.THREE.Mesh(new window.THREE.BoxGeometry(0.1,0.1,0.1), new window.THREE.MeshPhongMaterial({color:0xff0000})));
+                    console.log('URDFLoader (functional stub): Mesh loaded and added.');
+                    this.manager.itemEnd('stub_mesh.stl');
+                }.bind(this), function(err){
+                    console.error('URDFLoader (functional stub): Mesh failed to load.', err);
+                    this.manager.itemError('stub_mesh.stl');
+                }.bind(this));
+            }
+            // Simulate overall loading complete
+            setTimeout(function(){ if(this.manager.onLoad) this.manager.onLoad(); }.bind(this), 100);
+            return robot;
+        };
+        this.load = function(url, onLoad, onProgress, onError) {
+            console.log('URDFLoader (functional stub): load called for', url);
+            this.manager.itemStart(url);
+            // Simulate fetch and parse
+            const self = this;
+            setTimeout(function() {
+                const robot = self.parse('stub urdf content', url.substring(0, url.lastIndexOf('/') + 1));
+                if (onLoad) onLoad(robot);
+                self.manager.itemEnd(url);
+            }, 50);
+        };
     };
-    this.parse = function(content, path) {
-        console.log('URDFLoader.parse stub called with path:', path);
-        this.path = path; // Store path
-        const robot = new window.THREE.Group();
-        robot.name = path || 'parsed_robot';
-        // Simulate the loadMeshCb structure if needed by the real main.js
-        if (typeof this.loadMeshCb === 'function') {
-            console.log('URDFLoader.parse stub: loadMeshCb is defined, would simulate mesh loading here if parse was more complex.');
-        } else {
-             console.log('URDFLoader.parse stub: loadMeshCb is NOT defined.');
-        }
-        return robot;
-    };
-    this.loadMeshCb = null; // Placeholder for the callback from main_app.js
-    this.workingPath = ''; // For compatibility
-};
 
-window.STLLoader = function(manager) {
-    console.log('STLLoader stub created');
-    this.setPath = function(path) { this.path = path; };
-    this.load = function(url, onLoad, onProgress, onError) {
-        console.log('STLLoader.load stub called for:', this.path ? this.path + url : url);
-        if (onLoad) onLoad(new window.THREE.BoxGeometry()); else if (onError) onError(new Error('STLLoader stub error'));
-    };
-};
+    window.STLLoader = function(manager) { this.manager = manager || new window.THREE.LoadingManager(); this.setPath = function(p){this.path=p;}; this.load = function(url, onLoad){console.log('STLLoader (stub) load:', (this.path||'')+url ); this.manager.itemStart(url); const geom = new window.THREE.BoxGeometry(0.2,0.2,0.2); geom.name=url; onLoad(geom); this.manager.itemEnd(url);};};
+    window.OBJLoader = function(manager) { this.manager = manager || new window.THREE.LoadingManager(); this.setPath = function(p){this.path=p;}; this.load = function(url, onLoad){console.log('OBJLoader (stub) load:', (this.path||'')+url ); this.manager.itemStart(url); const group = new window.THREE.Group(); group.name=url; onLoad(group); this.manager.itemEnd(url);};};
+    window.ColladaLoader = function(manager) { this.manager = manager || new window.THREE.LoadingManager(); this.setPath = function(p){this.path=p;}; this.load = function(url, onLoad){console.log('ColladaLoader (stub) load:', (this.path||'')+url ); this.manager.itemStart(url); const scene = new window.THREE.Group(); scene.name=url; onLoad({scene: scene}); this.manager.itemEnd(url);};};
 
-window.OBJLoader = function(manager) {
-    console.log('OBJLoader stub created');
-    this.setPath = function(path) { this.path = path; };
-    this.load = function(url, onLoad, onProgress, onError) {
-        console.log('OBJLoader.load stub called for:', this.path ? this.path + url : url);
-        if (onLoad) onLoad(new window.THREE.Group()); else if (onError) onError(new Error('OBJLoader stub error'));
-    };
-};
+    console.log('three_with_loaders.bundle.js (Functional Partial Bundle) has been fully executed and globals set.');
 
-window.ColladaLoader = function(manager) {
-    console.log('ColladaLoader stub created');
-    this.setPath = function(path) { this.path = path; };
-    this.load = function(url, onLoad, onProgress, onError) {
-        console.log('ColladaLoader.load stub called for:', this.path ? this.path + url : url);
-        const scene = new window.THREE.Group();
-        if (onLoad) onLoad({ scene: scene }); else if (onError) onError(new Error('ColladaLoader stub error'));
-    };
-};
-
-console.log('three_with_loaders.bundle.js (Placeholder with Stubs) executed.');
+})(); // End IIFE


### PR DESCRIPTION
I've replaced the basic stubs in `three_with_loaders.bundle.js` with more functional, albeit still partial, implementations of Three.js r158 and its loaders (URDF, Collada, STL, OBJ).

These new stubs:
- Provide a more detailed `window.THREE` object with common classes and methods that log usage and simulate basic behavior (e.g., Object3D hierarchy, basic geometry/material creation logs, functional Clock, more complete WebGLRenderer stub with a real canvas domElement).
- Include loader stubs that interact with a stubbed `THREE.LoadingManager` and simulate basic `onLoad` callbacks. The URDFLoader stub, for example, attempts to simulate a mesh loading cycle.

This change aims to allow `main_app.js` to execute more of its logic without hitting missing methods/properties in the stubs, providing better console log feedback on the application's interaction with the (stubbed) Three.js library. Actual 3D rendering is still not performed by these stubs.