### PR TITLE
Okay, I've added some detailed console logging to help inspect `THREE…

### DIFF
--- a/main_app.js
+++ b/main_app.js
@@ -32,6 +32,10 @@ let p2pConstraint = null;
 
 // Mouse/Touch Interaction for Dragging IK Target
 const raycaster = new THREE.Raycaster();
+console.log("[Debug] Just before new THREE.Vector2(): typeof THREE:", typeof THREE);
+console.log("[Debug] Just before new THREE.Vector2(): THREE itself:", THREE);
+if (THREE) { console.log("[Debug] Just before new THREE.Vector2(): typeof THREE.Vector2:", typeof THREE.Vector2); }
+if (THREE) { console.log("[Debug] Just before new THREE.Vector2(): THREE.Vector2 content:", THREE.Vector2 ? THREE.Vector2.toString() : "undefined or null"); }
 const mouse = new THREE.Vector2();
 let isDraggingTarget = false;
 let dragPlane;


### PR DESCRIPTION
….Vector2`.

I put the `console.log` statements in `main_app.js` right before `new THREE.Vector2()` is created. These logs will show you the type and content of the `THREE` object and its `Vector2` property at that exact moment.

This should help us figure out why you're seeing the "Uncaught TypeError: THREE.Vector2 is not a constructor" error by showing us what `main_app.js` thinks `THREE.Vector2` is after `three_with_loaders.bundle.js` (stubs) has run.