### PR TITLE
Fix: Add missing methods to THREE.Vector3 stub

### DIFF
--- a/three_with_loaders.bundle.js
+++ b/three_with_loaders.bundle.js
@@ -3,30 +3,58 @@
 // The real bundle would contain the full minified Three.js r158 and loaders.
 
 (function() { // IIFE to encapsulate and manage scope
-    const THREE_CORE = {};
-    THREE_CORE.REVISION = '158-partial-bundle-v3'; // New version for this fix
 
-    // --- Vector2 (verified working) ---
+    const THREE_CORE = {};
+    THREE_CORE.REVISION = '158-partial-bundle-v4'; // New version for this fix
+
     THREE_CORE.Vector2 = function(x, y) { this.x = x || 0; this.y = y || 0; };
     THREE_CORE.Vector2.prototype = { set: function(x, y) { this.x = x; this.y = y; return this; }, copy: function(v) { this.x = v.x; this.y = v.y; return this; }, clone: function() { return new THREE_CORE.Vector2(this.x, this.y); } };
 
-    // --- Vector3 (verified working) ---
     THREE_CORE.Vector3 = function(x, y, z) { this.x = x || 0; this.y = y || 0; this.z = z || 0; };
-    THREE_CORE.Vector3.prototype = { set: function(x, y, z) { this.x = x; this.y = y; this.z = z; return this; }, copy: function(v) { this.x = v.x; this.y = v.y; this.z = v.z; return this; }, addScaledVector: function(v, s) { this.x += v.x * s; this.y += v.y * s; this.z += v.z * s; return this; }, normalize: function() { const l = Math.sqrt(this.x*this.x+this.y*this.y+this.z*this.z) || 1; this.x/=l; this.y/=l; this.z/=l; return this;}, clone: function() { return new THREE_CORE.Vector3(this.x, this.y, this.z); }, dot: function(v) { return this.x * v.x + this.y * v.y + this.z * v.z; } };
+    THREE_CORE.Vector3.prototype = {
+        set: function(x, y, z) { this.x = x; this.y = y; this.z = z; return this; },
+        copy: function(v) { this.x = v.x; this.y = v.y; this.z = v.z; return this; },
+        add: function(v) { this.x += v.x; this.y += v.y; this.z += v.z; return this; },
+        addScaledVector: function(v, s) { this.x += v.x * s; this.y += v.y * s; this.z += v.z * s; return this; },
+        multiplyScalar: function(s) { this.x *= s; this.y *= s; this.z *= s; return this; },
+        sub: function(v) { this.x -= v.x; this.y -= v.y; this.z -= v.z; return this; },
+        lengthSq: function() { return this.x * this.x + this.y * this.y + this.z * this.z; }, // Added for length
+        length: function() { return Math.sqrt(this.lengthSq()); },
+        normalize: function() { const l = this.length() || 1; this.x /= l; this.y /= l; this.z /= l; return this;},
+        clone: function() { return new THREE_CORE.Vector3(this.x, this.y, this.z); },
+        dot: function(v) { return this.x * v.x + this.y * v.y + this.z * v.z; }
+        // applyQuaternion will be added after Quaternion is defined
+    };
 
-    // --- Quaternion (verified working) ---
     THREE_CORE.Quaternion = function(x,y,z,w) { this.x=x||0; this.y=y||0; this.z=z||0; this.w=(w===undefined)?1:w; };
-    THREE_CORE.Quaternion.prototype = { set: function(x,y,z,w) {this.x=x; this.y=y; this.z=z; this.w=w; return this;}, copy: function(q) {this.x=q.x; this.y=q.y; this.z=q.z; this.w=q.w; return this;}, clone: function() { return new THREE_CORE.Quaternion(this.x, this.y, this.z, this.w); }, multiplyQuaternions: function(a,b){ this.copy(a); return this;}, premultiply: function(q){ return this; }, setFromEuler: function(e){ return this;}, normalize: function() {return this;} , _applyToVector3: function(v) { return v; }};
+    THREE_CORE.Quaternion.prototype = {
+        set: function(x,y,z,w) {this.x=x; this.y=y; this.z=z; this.w=w; return this;},
+        copy: function(q) {this.x=q.x; this.y=q.y; this.z=q.z; this.w=q.w; return this;},
+        clone: function() { return new THREE_CORE.Quaternion(this.x, this.y, this.z, this.w); },
+        multiplyQuaternions: function(a,b){ this.copy(a); return this;},
+        premultiply: function(q){ return this; },
+        setFromEuler: function(e){ return this;},
+        normalize: function() {return this;},
+        _applyToVector3: function(vector) { // More functional stub for applyQuaternion
+            const x = vector.x, y = vector.y, z = vector.z;
+            const qx = this.x, qy = this.y, qz = this.z, qw = this.w;
+            // calculate quat * vector
+            const ix = qw * x + qy * z - qz * y;
+            const iy = qw * y + qz * x - qx * z;
+            const iz = qw * z + qx * y - qy * x;
+            const iw = -qx * x - qy * y - qz * z;
+            // calculate result * inverse quat
+            vector.x = ix * qw + iw * -qx + iy * -qz - iz * -qy;
+            vector.y = iy * qw + iw * -qy + iz * -qx - ix * -qz;
+            vector.z = iz * qw + iw * -qz + ix * -qy - iy * -qx;
+            return vector;
+        }
+    };
     THREE_CORE.Vector3.prototype.applyQuaternion = function(q) { return q._applyToVector3(this); };
 
-    // --- Color (verified working) ---
     THREE_CORE.Color = function(r, g, b) { if (g === undefined && b === undefined) { this.setHex(r); } else { this.setRGB(r,g,b); } };
     THREE_CORE.Color.prototype = { setRGB: function(r,g,b) { this.r=r; this.g=g; this.b=b; return this;}, setHex: function(hex) { hex = Math.floor(hex); this.r = (hex >> 16 & 255) / 255; this.g = (hex >> 8 & 255) / 255; this.b = (hex & 255) / 255; return this;}, clone: function() { return new THREE_CORE.Color(this.r, this.g, this.b); } };
-
-    // --- Object3D (verified working) ---
     THREE_CORE.Object3D = function() { this.position = new THREE_CORE.Vector3(); this.quaternion = new THREE_CORE.Quaternion(); this.children = []; this.up = new THREE_CORE.Vector3(0,1,0); this.name = ''; this.visible = true; this.parent = null; this.add = function(child) { if (child === this) { console.error('THREE.Object3D.add: An object can\'t be added as a child of itself.'); return this;} this.children.push(child); child.parent = this; return this; }; this.remove = function(child) { const index = this.children.indexOf(child); if (index !== -1) { child.parent = null; this.children.splice(index, 1);}}; this.lookAt = function(vector_or_x, y, z) { console.log('Object3D.lookAt called');}; this.getWorldDirection = function(target) { return target.set(0,0,-1).applyQuaternion(this.quaternion);}; this.traverse = function(callback) { callback(this); for(let i=0; i<this.children.length; i++) { this.children[i].traverse(callback); } }; };
-
-    // --- Group, Scene, PerspectiveCamera, WebGLRenderer, Lights, Geometries, Materials, Mesh, Plane (verified stubs from previous successful run) ---
     THREE_CORE.Group = function() { THREE_CORE.Object3D.call(this); this.type = 'Group'; console.log('THREE.Group stub created'); };
     THREE_CORE.Group.prototype = Object.assign(Object.create(THREE_CORE.Object3D.prototype), { constructor: THREE_CORE.Group });
     THREE_CORE.Scene = function() { THREE_CORE.Object3D.call(this); this.type = 'Scene'; this.background = null; console.log('THREE.Scene stub created');};
@@ -44,33 +72,15 @@
     THREE_CORE.Mesh = function(geometry, material) { THREE_CORE.Object3D.call(this); this.type = 'Mesh'; this.geometry = geometry; this.material = material; console.log('Mesh created');};
     THREE_CORE.Mesh.prototype = Object.assign(Object.create(THREE_CORE.Object3D.prototype), { constructor: THREE_CORE.Mesh });
     THREE_CORE.Plane = function() {this.type='Plane'; this.normal = new THREE_CORE.Vector3(0,1,0); this.constant = 0; this.setFromNormalAndCoplanarPoint=function(n,p){this.normal.copy(n); this.constant = -p.dot(this.normal); return this;}; console.log('THREE.Plane stub created');};
-
-    // --- Raycaster (verified working) ---
     THREE_CORE.Raycaster = function(origin, direction, near, far){ this.ray={origin: origin || new THREE_CORE.Vector3(), direction: direction || new THREE_CORE.Vector3()}; this.near=near||0; this.far=far||Infinity; this.params = {}; this.setFromCamera=function(coords, camera){ console.log('Raycaster.setFromCamera called with coords:', coords, 'and camera:', camera ? camera.type : 'no camera'); this.ray.origin.set(0,0,0); this.ray.direction.set(coords.x, coords.y, -1).normalize(); }; this.intersectObject=function(object, recursive){ console.log('Raycaster.intersectObject called on object:', object ? object.name : 'no object', 'recursive:', recursive); return[]; }; this.ray.intersectPlane = function(plane, optionalTarget) { console.log('Raycaster.ray.intersectPlane called'); if (optionalTarget) { return optionalTarget.set(1,1,0); } return new THREE_CORE.Vector3(1,1,0); }; console.log('THREE.Raycaster stub created');};
-
-    // --- Clock (verified working) ---
     THREE_CORE.Clock = function(autoStart) { this.autoStart = (autoStart !== undefined) ? autoStart : true; this.startTime = 0; this.oldTime = 0; this.elapsedTime = 0; this.running = false; if (this.autoStart) this.start(); console.log('THREE.Clock stub created');};
     THREE_CORE.Clock.prototype = { start: function() {this.startTime = (typeof performance === 'undefined' ? Date : performance).now(); this.oldTime = this.startTime; this.elapsedTime = 0; this.running = true;}, stop: function(){this.getElapsedTime(); this.running = false; return this;}, getElapsedTime: function(){this.getDelta(); return this.elapsedTime;}, getDelta: function(){ let diff = 0; if (this.running) { const newTime = (typeof performance === 'undefined' ? Date : performance).now(); diff = (newTime - this.oldTime) / 1000; this.oldTime = newTime; this.elapsedTime += diff; } return diff; } };
-
-    // --- Box3 and Sphere (verified working) ---
     THREE_CORE.Box3 = function(min, max) { this.min = (min !== undefined) ? min : new THREE_CORE.Vector3(+Infinity,+Infinity,+Infinity); this.max = (max !== undefined) ? max : new THREE_CORE.Vector3(-Infinity,-Infinity,-Infinity); console.log('THREE.Box3 stub created');};
     THREE_CORE.Box3.prototype = { setFromObject: function(object){ console.log('Box3.setFromObject called for object:', object ? object.name : 'no object'); this.min.set(-0.5, -0.5, -0.5); this.max.set( 0.5,  0.5,  0.5); if (object && object.children && object.children.length === 0 && (!object.geometry && !object.material)) { this.min.set(0,0,0); this.max.set(0,0,0); } return this; }, getCenter: function(target){ if (!target) {target = new THREE_CORE.Vector3();} return target.copy(this.min).add(this.max).multiplyScalar(0.5);}, getSize: function(target){ if (!target) {target = new THREE_CORE.Vector3();} return target.copy(this.max).sub(this.min);}, getBoundingSphere: function(target){ if (!target) {target = new THREE_CORE.Sphere();} this.getCenter(target.center); target.radius = this.getSize(new THREE_CORE.Vector3()).length() * 0.5; console.log('Box3.getBoundingSphere calculated center:', target.center, 'radius:', target.radius); return target; } };
     THREE_CORE.Sphere = function(center, radius){ this.center = (center !== undefined) ? center : new THREE_CORE.Vector3(); this.radius = (radius !== undefined) ? radius : -1; console.log('THREE.Sphere stub created');};
-
-    // --- ADDED/FIXED LoadingManager ---
-    THREE_CORE.LoadingManager = function(onLoad, onProgress, onError) {
-        console.log('THREE.LoadingManager stub created');
-        this.onLoad = onLoad;
-        this.onProgress = onProgress;
-        this.onError = onError;
-        this.itemStart = function(url){ console.log('LoadingManager: itemStart', url); this.loading = true; }; // Added this.loading flag
-        this.itemEnd = function(url){ console.log('LoadingManager: itemEnd', url); this.loading = false; if(this.onLoad) this.onLoad(); }; // Simplified: call onLoad if it exists
-        this.itemError = function(url){ console.log('LoadingManager: itemError', url); if(this.onError) this.onError(url); };
-        this.loading = false; // Flag to track if any item is loading
-    };
-
-    // Assign to global window.THREE
+    THREE_CORE.LoadingManager = function(onLoad, onProgress, onError) { console.log('THREE.LoadingManager stub created'); this.onLoad = onLoad; this.onProgress = onProgress; this.onError = onError; this.itemStart = function(url){ console.log('LoadingManager: itemStart', url); this.loading = true; }; this.itemEnd = function(url){ console.log('LoadingManager: itemEnd', url); this.loading = false; if(this.onLoad) this.onLoad(); }; this.itemError = function(url){ console.log('LoadingManager: itemError', url); if(this.onError) this.onError(url); }; this.loading = false; };
     window.THREE = THREE_CORE;
+
     // --- Loader Implementations (Simplified stubs for brevity in this example) ---
     // In a real scenario, the full minified code for these loaders would be here.
     window.URDFLoader = function(manager) {


### PR DESCRIPTION
Updated the `THREE.Vector3.prototype` stub in
`three_with_loaders.bundle.js` to include the methods `add(v)`, `multiplyScalar(s)`, `sub(v)`, `length()`, and `lengthSq()`. Also improved the `Quaternion._applyToVector3` stub for better simulation of `Vector3.applyQuaternion`.

This resolves the "TypeError: target.copy(...).add is not a function" that occurred in the `THREE.Box3.getCenter` stub (called by `fitCameraToObject`) due to these missing Vector3 methods.

This allows the `fitCameraToObject` logic to proceed further when using the stubbed Three.js environment.