### PR TITLE
Fix: Enhance Raycaster and Vector3 stubs in three_r128_libs.js

### DIFF
--- a/three_r128_libs.js
+++ b/three_r128_libs.js
@@ -1,9 +1,9 @@
-// three_r128_libs.js - Comprehensive stubs with direct global THREE assignment (v4)
+// three_r128_libs.js - Comprehensive stubs with direct global THREE assignment (v5 - Raycaster fixes)
 
 var THREE = {
-    REVISION: '128-direct-global-v4'
+    REVISION: '128-direct-global-v5'
 };
-console.log('THREE.js (r128 stub v4) global THREE object initialized.');
+console.log('THREE.js (r128 stub v5) global THREE object initialized.');
 
 // --- Core Math Components ---
 THREE.Vector2 = function(x, y) { this.x = x || 0; this.y = y || 0; };
@@ -27,7 +27,19 @@ THREE.Vector3.prototype = {
     length: function() { return Math.sqrt(this.lengthSq()); },
     normalize: function() { const l = this.length() || 1; this.x /= l; this.y /= l; this.z /= l; return this;},
     clone: function() { return new THREE.Vector3(this.x, this.y, this.z); },
-    dot: function(v) { return this.x * v.x + this.y * v.y + this.z * v.z; }
+    dot: function(v) { return this.x * v.x + this.y * v.y + this.z * v.z; },
+    unproject: function(camera) { console.log('Vector3.unproject (stub) called'); /* simplified - real unproject is complex */ this.x = (this.x * 100); this.y = (this.y * 100); this.z = (this.z * -1 ); return this; }, // ADDED & Basic stub
+    setFromMatrixPosition: function(m) { console.log('Vector3.setFromMatrixPosition (stub) called'); this.set(m.elements[12], m.elements[13], m.elements[14]); return this; }
+};
+
+THREE.Matrix4 = function() {
+    this.elements = [1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1]; // Identity matrix
+    console.log('THREE.Matrix4 (r128 stub) created');
+};
+THREE.Matrix4.prototype = {
+    constructor: THREE.Matrix4,
+    identity: function() { this.elements = [1,0,0,0, 0,1,0,0, 0,0,1,0, 0,0,0,1]; return this; },
+    clone: function() { const m = new THREE.Matrix4(); m.elements = this.elements.slice(); return m; }
 };
 
 THREE.Quaternion = function(x,y,z,w) { this.x=x||0; this.y=y||0; this.z=z||0; this.w=(w===undefined)?1:w; };
@@ -52,6 +64,7 @@ THREE.Color.prototype = { constructor: THREE.Color, setRGB: function(r,g,b) { th
 THREE.Object3D = function() {
     this.position = new THREE.Vector3();
     this.quaternion = new THREE.Quaternion();
+    this.matrixWorld = new THREE.Matrix4();
     this.children = [];
     this.up = new THREE.Vector3(0,1,0);
     this.name = '';
@@ -65,20 +78,22 @@ THREE.Object3D = function() {
 };
 THREE.Object3D.prototype = {
     constructor: THREE.Object3D,
-    add: THREE.Object3D.prototype.add, // This is not how prototype methods are typically defined.
-    remove: THREE.Object3D.prototype.remove, // Should be defined directly on prototype.
+    // Re-assigning instance methods to prototype is not standard. Define them on prototype directly or use Object.assign.
+    // For stubs, this might be okay if these methods are simple and don't rely on 'this' in a complex way from constructor.
+    // However, it's better to define methods on prototype properly.
+    // For now, keeping user's structure for this part, but noting it.
+    add: THREE.Object3D.prototype.add,
+    remove: THREE.Object3D.prototype.remove,
     lookAt: THREE.Object3D.prototype.lookAt,
     getWorldDirection: THREE.Object3D.prototype.getWorldDirection,
     traverse: THREE.Object3D.prototype.traverse,
     applyQuaternion: function(q) { this.quaternion.premultiply(q); return this; /*stub*/ },
-    // Adding a basic clone for Object3D, Group, etc.
     clone: function(recursive) {
-        var newObj = new this.constructor(); // Use this.constructor for proper cloning of subclasses
+        var newObj = new this.constructor();
         newObj.name = this.name;
-        newObj.up.copy(this.up);
-        newObj.position.copy(this.position);
-        newObj.quaternion.copy(this.quaternion);
-        // Not copying other properties like scale, matrix, etc. for this stub
+        if(newObj.up && this.up) newObj.up.copy(this.up); // Check if up exists
+        if(newObj.position && this.position) newObj.position.copy(this.position);
+        if(newObj.quaternion && this.quaternion) newObj.quaternion.copy(this.quaternion);
         if (recursive !== false) {
             for (var i = 0; i < this.children.length; i++) {
                 newObj.add(this.children[i].clone());
@@ -95,7 +110,7 @@ THREE.Group.prototype = Object.assign(Object.create(THREE.Object3D.prototype), {
 THREE.Scene = function() { THREE.Object3D.call(this); this.type = 'Scene'; this.background = null; console.log('THREE.Scene (r128 stub) created');};
 THREE.Scene.prototype = Object.assign(Object.create(THREE.Object3D.prototype), { constructor: THREE.Scene });
 
-THREE.PerspectiveCamera = function(fov, aspect, near, far) { THREE.Object3D.call(this); this.type='PerspectiveCamera'; this.fov=fov; this.aspect=aspect; this.near=near; this.far=far; this.updateProjectionMatrix = function(){ console.log('PerspectiveCamera.updateProjectionMatrix called (stub)');}; console.log('THREE.PerspectiveCamera (r128 stub) created');};
+THREE.PerspectiveCamera = function(fov, aspect, near, far) { THREE.Object3D.call(this); this.type='PerspectiveCamera'; this.fov=fov; this.aspect=aspect; this.near=near; this.far=far; this.matrixWorld = new THREE.Matrix4(); this.projectionMatrix = new THREE.Matrix4(); this.projectionMatrixInverse = new THREE.Matrix4(); this.updateProjectionMatrix = function(){ console.log('PerspectiveCamera.updateProjectionMatrix called (stub)');}; console.log('THREE.PerspectiveCamera (r128 stub) created');};
 THREE.PerspectiveCamera.prototype = Object.assign(Object.create(THREE.Object3D.prototype), { constructor: THREE.PerspectiveCamera });
 
 THREE.WebGLRenderer = function(params) { console.log('THREE.WebGLRenderer (r128 stub) created'); this.domElement = document.createElement('canvas'); this.domElement.width = 300; this.domElement.height = 150; if(params && params.canvas) {this.domElement = params.canvas;} this.setSize = function(width, height) { this.domElement.width = width; this.domElement.height = height; console.log('Renderer.setSize (r128 stub):', width, height); }; this.render = function(scene, camera) { /* console.log('Renderer.render called (stub)'); */ }; this.setAnimationLoop = function(callback) { this.animationLoop = callback; console.log('Renderer.setAnimationLoop set (stub).'); var scope = this; function loop() { if(scope.animationLoop) {scope.animationLoop();} requestAnimationFrame(loop); } requestAnimationFrame(loop); }; };
@@ -110,8 +125,8 @@ THREE.BoxGeometry = function(w,h,d) {this.type='BoxGeometry'; console.log('BoxGe
 THREE.SphereGeometry = function(r) {this.type='SphereGeometry'; console.log('SphereGeometry (r128 stub) created:',r);};
 THREE.BufferGeometry = function() {this.type='BufferGeometry'; console.log('BufferGeometry (r128 stub) created'); this.dispose = function(){ console.log('BufferGeometry.dispose() called'); }; };
 
-THREE.Material = function() { this.name = ''; this.type='Material'; console.log('THREE.Material (r128 stub) created'); };
-THREE.Material.prototype = {constructor: THREE.Material, needsUpdate: false, dispose: function(){ console.log('Material.dispose() called'); }};
+THREE.Material = function() { this.name = ''; this.type='Material'; console.log('THREE.Material (r128 stub) created'); this.dispose = function(){console.log('Material.dispose() called');};};
+THREE.Material.prototype = {constructor: THREE.Material, needsUpdate: false, dispose: THREE.Material.prototype.dispose};
 
 THREE.MeshPhongMaterial = function(params) { THREE.Material.call(this); this.type = 'MeshPhongMaterial'; this.color = (params && params.color) ? new THREE.Color(params.color) : new THREE.Color(0xffffff); this.wireframe = (params && params.wireframe) || false; if(params && params.name) this.name = params.name; console.log('MeshPhongMaterial (r128 stub) created:', params);};
 THREE.MeshPhongMaterial.prototype = Object.assign(Object.create(THREE.Material.prototype), { constructor: THREE.MeshPhongMaterial });
@@ -121,7 +136,30 @@ THREE.Mesh.prototype = Object.assign(Object.create(THREE.Object3D.prototype), { 
 
 THREE.Plane = function() {this.type='Plane'; this.normal = new THREE.Vector3(0,1,0); this.constant = 0; this.setFromNormalAndCoplanarPoint=function(n,p){this.normal.copy(n); this.constant = -p.dot(this.normal); return this;}; console.log('THREE.Plane (r128 stub) created');};
 
-THREE.Raycaster = function(origin, direction, near, far){ this.ray={origin: origin || new THREE.Vector3(), direction: direction || new THREE.Vector3()}; this.near=near||0; this.far=far||Infinity; this.params = {}; this.setFromCamera=function(coords, camera){ console.log('Raycaster.setFromCamera (r128 stub) called'); if(this.ray && this.ray.origin && this.ray.direction && camera && camera.position){this.ray.origin.copy(camera.position); this.ray.direction.set(coords.x, coords.y, 0.5).unproject(camera).sub(camera.position).normalize();} }; this.intersectObject=function(object, recursive){ console.log('Raycaster.intersectObject (r128 stub) called on object:', object ? object.name : 'no object'); return[]; }; this.ray.intersectPlane = function(plane, optionalTarget) { console.log('Raycaster.ray.intersectPlane (r128 stub) called'); if (optionalTarget) { return optionalTarget.set(1,1,0); } return new THREE.Vector3(1,1,0); }; console.log('THREE.Raycaster (r128 stub) created');};
+THREE.Raycaster = function(origin, direction, near, far){
+    this.ray={origin: new THREE.Vector3(), direction: new THREE.Vector3()};
+    if(origin) this.ray.origin.copy(origin);
+    if(direction) this.ray.direction.copy(direction);
+    this.near=near||0;
+    this.far=far||Infinity;
+    this.params = {};
+    this.camera = null; // Added for unproject logic
+    this.setFromCamera=function(coords, camera){
+        console.log('Raycaster.setFromCamera (r128 stub v2) called');
+        this.camera = camera; // Store camera reference
+        if (camera && camera.matrixWorld) {
+             this.ray.origin.setFromMatrixPosition(camera.matrixWorld); // Use setFromMatrixPosition
+             this.ray.direction.set(coords.x, coords.y, 0.5).unproject(camera).sub(this.ray.origin).normalize();
+        } else {
+            console.warn('Raycaster.setFromCamera stub: camera or camera.matrixWorld is undefined.');
+            this.ray.origin.set(0,0,0);
+            this.ray.direction.set(coords.x, coords.y, -1).normalize();
+        }
+    };
+    this.intersectObject=function(object, recursive){ console.log('Raycaster.intersectObject (r128 stub) called on object:', object ? object.name : 'no object'); return[]; };
+    this.ray.intersectPlane = function(plane, optionalTarget) { console.log('Raycaster.ray.intersectPlane (r128 stub) called'); if (optionalTarget) { return optionalTarget.set(1,1,0); } return new THREE.Vector3(1,1,0); };
+    console.log('THREE.Raycaster (r128 stub v2) created');
+};
 
 THREE.Clock = function(autoStart) { this.autoStart = (autoStart !== undefined) ? autoStart : true; this.startTime = 0; this.oldTime = 0; this.elapsedTime = 0; this.running = false; if (this.autoStart) this.start(); console.log('THREE.Clock (r128 stub) created');};
 THREE.Clock.prototype = { constructor: THREE.Clock, start: function() {this.startTime = (typeof performance === 'undefined' ? Date : performance).now(); this.oldTime = this.startTime; this.elapsedTime = 0; this.running = true;}, stop: function(){this.getElapsedTime(); this.running = false; return this;}, getElapsedTime: function(){this.getDelta(); return this.elapsedTime;}, getDelta: function(){ let diff = 0; if (this.running) { const newTime = (typeof performance === 'undefined' ? Date : performance).now(); diff = (newTime - this.oldTime) / 1000; this.oldTime = newTime; this.elapsedTime += diff; } return diff; } };
@@ -154,7 +192,7 @@ THREE.XHRLoader = function ( manager ) {
     this.load = function ( url, onLoad, onProgress, onError ) {
         console.log('THREE.XHRLoader (stub v4) load:', url);
         if (this.manager) this.manager.itemStart(url);
-        if (url.endsWith('.urdf') || url.endsWith('.xml')) { // Allow .xml for URDFs too
+        if (url.endsWith('.urdf') || url.endsWith('.xml')) {
              if (this.manager) this.manager.itemEnd(url);
              if (onLoad) onLoad('<robot name=\"test_robot\"><link name=\"link1\"><visual><geometry><box size=\"1 1 1\" /></visual></link></robot>');
         } else {
@@ -196,7 +234,6 @@ THREE.URDFLoader = function ( manager ) {
         var link = new THREE.Object3D(); link.name = 'link1_stub_v4'; robot.add(link);
         if (this.loadMeshCb && typeof this.loadMeshCb === 'function') {
             console.log('URDFLoader stub v4: Calling loadMeshCb for a mock mesh.');
-            // Simulate a mesh path that the callback might expect
             this.loadMeshCb('package://dummy_package/meshes/dummy_mesh.stl', this.manager, function(mesh_model){
                 if(mesh_model) { link.add(mesh_model); console.log('URDFLoader stub v4: Mock mesh added to link.'); }
                 else { console.warn('URDFLoader stub v4: Mock mesh callback received null/undefined mesh.');}
@@ -218,4 +255,4 @@ THREE.OBJLoader = function (manager) { this.manager = manager || THREE.DefaultLo
 THREE.ColladaLoader = function (manager) { this.manager = manager || THREE.DefaultLoadingManager; console.log('THREE.ColladaLoader (r128 stub) created.'); this.setPath = function(p){this.path=p;}; this.load = function(url, onLoad){ console.log('ColladaLoader (r128 stub) load:', (this.path||'')+url ); if(onLoad) onLoad({ scene: new THREE.Group() }); }; };
 console.log('Other loader stubs (r128 v4) defined.');
 
-console.log('three_r128_libs.js (Comprehensive Stubs v4 - direct global) executed.');
+console.log('three_r128_libs.js (Comprehensive Stubs v5 - Raycaster fix) executed.');


### PR DESCRIPTION
Updated `three_r128_libs.js` (to v5) with more functional stubs for `THREE.Raycaster.setFromCamera` and its dependencies to resolve the "TypeError: this.ray.direction.set(...).unproject is not a function" error.

Key changes:
- `THREE.Vector3.prototype`: Added `unproject(camera)` and `setFromMatrixPosition(matrix)` method stubs.
- `THREE.Matrix4`: Added a basic stub for `Matrix4`.
- `THREE.Object3D` and `THREE.PerspectiveCamera`: Added `matrixWorld` property (stubbed as `new THREE.Matrix4()`).
- `THREE.Raycaster.setFromCamera`: Stub updated to more closely mimic the real implementation's logic chain, using the new Vector3 methods and `camera.matrixWorld`.

This should allow the mouse event handlers (which use the Raycaster for IK target interaction) to execute without crashing in the stubbed Three.js r128 environment. Actual 3D rendering is still not performed by these stubs.